### PR TITLE
Add basic crypto exchange with admin commissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# cryptoexchange
+# Cryptoexchange
+
+This is a minimal demonstration of a crypto exchange-like service with an admin panel.
+
+Features:
+- Users can deposit funds, withdraw funds, and transfer funds to other users.
+- Each operation applies a commission that is credited to the admin account.
+- Admin panel endpoint `/admin/summary` shows all user balances and total commission collected.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the app
+
+```bash
+python app.py
+```
+
+The application exposes HTTP endpoints and runs on `http://localhost:5000` by default.
+
+## Running tests
+
+```bash
+pytest
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,68 @@
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+users = {}
+admin = {"commission": 0.0}
+
+DEPOSIT_COMMISSION_RATE = 0.01
+WITHDRAWAL_COMMISSION_RATE = 0.01
+TRANSFER_COMMISSION_RATE = 0.01
+
+def get_user(username: str):
+    if username not in users:
+        users[username] = {"balance": 0.0}
+    return users[username]
+
+def reset_state():
+    users.clear()
+    admin["commission"] = 0.0
+
+@app.post("/deposit")
+def deposit():
+    data = request.get_json(force=True)
+    user = get_user(data["user"])
+    amount = float(data["amount"])
+    commission = amount * DEPOSIT_COMMISSION_RATE
+    user["balance"] += amount - commission
+    admin["commission"] += commission
+    return jsonify({"balance": user["balance"], "commission": commission})
+
+@app.post("/withdraw")
+def withdraw():
+    data = request.get_json(force=True)
+    user = get_user(data["user"])
+    amount = float(data["amount"])
+    commission = amount * WITHDRAWAL_COMMISSION_RATE
+    total = amount + commission
+    if user["balance"] < total:
+        return jsonify({"error": "insufficient funds"}), 400
+    user["balance"] -= total
+    admin["commission"] += commission
+    return jsonify({"balance": user["balance"], "commission": commission})
+
+@app.post("/transfer")
+def transfer():
+    data = request.get_json(force=True)
+    from_user = get_user(data["from"])
+    to_user = get_user(data["to"])
+    amount = float(data["amount"])
+    commission = amount * TRANSFER_COMMISSION_RATE
+    total = amount + commission
+    if from_user["balance"] < total:
+        return jsonify({"error": "insufficient funds"}), 400
+    from_user["balance"] -= total
+    to_user["balance"] += amount
+    admin["commission"] += commission
+    return jsonify({
+        "from_balance": from_user["balance"],
+        "to_balance": to_user["balance"],
+        "commission": commission,
+    })
+
+@app.get("/admin/summary")
+def admin_summary():
+    return jsonify({"admin_commission": admin["commission"], "users": users})
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+pytest

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,35 @@
+import json
+import pytest
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app import app, users, admin, reset_state
+
+@pytest.fixture(autouse=True)
+def run_around_tests():
+    reset_state()
+    yield
+    reset_state()
+
+def test_deposit_commission():
+    client = app.test_client()
+    response = client.post("/deposit", json={"user": "alice", "amount": 100})
+    assert response.status_code == 200
+    assert users["alice"]["balance"] == pytest.approx(99.0)
+    assert admin["commission"] == pytest.approx(1.0)
+
+def test_withdraw_commission():
+    client = app.test_client()
+    client.post("/deposit", json={"user": "alice", "amount": 100})
+    response = client.post("/withdraw", json={"user": "alice", "amount": 50})
+    assert response.status_code == 200
+    assert users["alice"]["balance"] == pytest.approx(48.5)
+    assert admin["commission"] == pytest.approx(1.5)
+
+def test_transfer_commission():
+    client = app.test_client()
+    client.post("/deposit", json={"user": "alice", "amount": 100})
+    response = client.post("/transfer", json={"from": "alice", "to": "bob", "amount": 20})
+    assert response.status_code == 200
+    assert users["alice"]["balance"] == pytest.approx(78.8)
+    assert users["bob"]["balance"] == pytest.approx(20.0)
+    assert admin["commission"] == pytest.approx(1.2)


### PR DESCRIPTION
## Summary
- implement minimal Flask app supporting deposits, withdrawals, transfers, and admin commission summary
- document setup, running, and testing instructions
- add pytest suite covering commission calculations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890aca4fd88832b826f16f6c6c39cca