### PR TITLE
Create project skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# cryptoexchange
+# Crypto Exchange
+
+Minimal skeleton project for a cryptocurrency exchange.
+
+## Structure
+- `backend/` – Node.js Express API with placeholder routes for spot, futures, and liquidity.
+- `frontend/` – 2025-styled static web interface with panels for spot trading, futures, and liquidity provider tools.
+- `mobile/ios/` – placeholder for iOS app.
+- `mobile/android/` – placeholder for Android app.
+
+Further development is required to implement full trading functionality, security, and compliance.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cryptoexchange-backend",
+  "version": "0.1.0",
+  "description": "Minimal backend skeleton for crypto exchange.",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests yet\""
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const app = express();
+app.use(express.json());
+
+app.get('/', (req, res) => {
+  res.send('Crypto Exchange API');
+});
+
+// placeholder route for spot order
+app.post('/spot/order', (req, res) => {
+  res.json({ status: 'spot order endpoint' });
+});
+
+// placeholder route for futures order
+app.post('/futures/order', (req, res) => {
+  res.json({ status: 'futures order endpoint' });
+});
+
+// placeholder route for liquidity provider
+app.post('/liquidity', (req, res) => {
+  res.json({ status: 'liquidity provider endpoint' });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,11 @@
+# Frontend
+
+A minimal 2025-styled web interface for the crypto exchange.
+
+Features:
+- Futuristic glassmorphism design with neon accents
+- Panels for spot trading, futures, and liquidity provider interactions
+- Simple navigation that toggles between panels
+- Built with plain HTML, CSS, and JavaScript; ready for backend API integration
+
+To view, open `index.html` in a browser.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,14 @@
+function showPanel(type) {
+  ['spot', 'futures', 'liquidity'].forEach(t => {
+    const panel = document.getElementById(`${t}-panel`);
+    if (t === type) {
+      panel.classList.remove('hidden');
+    } else {
+      panel.classList.add('hidden');
+    }
+  });
+}
+
+document.getElementById('spot-link').addEventListener('click', () => showPanel('spot'));
+document.getElementById('futures-link').addEventListener('click', () => showPanel('futures'));
+document.getElementById('liquidity-link').addEventListener('click', () => showPanel('liquidity'));

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CryptoExchange 2025</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="top-nav">
+    <div class="logo">CryptoExchange</div>
+    <nav class="nav-links">
+      <a href="#" id="spot-link">Spot</a>
+      <a href="#" id="futures-link">Futures</a>
+      <a href="#" id="liquidity-link">Liquidity</a>
+    </nav>
+  </header>
+  <main id="content">
+    <section class="hero">
+      <h1>Trade the Future</h1>
+      <p>Experience next-gen trading with a sleek and intuitive interface.</p>
+    </section>
+    <section class="panel-container">
+      <div class="panel" id="spot-panel">Spot trading panel placeholder</div>
+      <div class="panel hidden" id="futures-panel">Futures trading panel placeholder</div>
+      <div class="panel hidden" id="liquidity-panel">Liquidity provider tools placeholder</div>
+    </section>
+  </main>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,68 @@
+body {
+  margin: 0;
+  font-family: 'Orbitron', sans-serif;
+  background: radial-gradient(circle at 25% -10%, #1e3c72, #2a5298 35%, #000000 100%);
+  color: #e5e5e5;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.top-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background: rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.5rem;
+  color: #00d4ff;
+}
+
+.nav-links a {
+  margin-left: 1.5rem;
+  color: #00d4ff;
+  text-decoration: none;
+  transition: color 0.3s ease;
+}
+
+.nav-links a:hover {
+  color: #72ffb6;
+}
+
+.hero {
+  text-align: center;
+  padding: 5rem 1rem;
+}
+
+.panel-container {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  padding: 2rem;
+  flex-wrap: wrap;
+}
+
+.panel {
+  width: 300px;
+  padding: 2rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 20px;
+  backdrop-filter: blur(15px);
+  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+  transition: transform 0.3s ease;
+}
+
+.panel:hover {
+  transform: translateY(-5px);
+}
+
+.hidden {
+  display: none;
+}

--- a/mobile/android/README.md
+++ b/mobile/android/README.md
@@ -1,0 +1,7 @@
+# Android App
+
+Placeholder for the Android client of the crypto exchange.
+
+Expected stack:
+- Kotlin
+- Communication with backend API

--- a/mobile/ios/README.md
+++ b/mobile/ios/README.md
@@ -1,0 +1,7 @@
+# iOS App
+
+Placeholder for the iOS client of the crypto exchange.
+
+Expected stack:
+- SwiftUI or UIKit
+- Communication with backend API


### PR DESCRIPTION
## Summary
- add Node.js backend skeleton with placeholder routes for spot, futures, and liquidity
- introduce 2025-styled web frontend with glassmorphic panels and interactive navigation
- document project structure and frontend features for future integration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890ac0ab898832bac19e0afd122298c