### PR TITLE
Add basic trading interface and API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+backend/node_modules
+backend/package-lock.json
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
+# CryptoExchange
 
+This repository contains a simple demonstration of a crypto trading interface and API.
 
+## Backend
 
+The backend server (`backend/server.js`) is a Node.js Express app that exposes:
+
+- `GET /api/markets` – list available trading pairs
+- `POST /api/orders` – place a new limit order
+- `GET /api/orders/open` – view open orders
+
+Run the server:
+
+```bash
+node backend/server.js
+```
+
+## Frontend
+
+A lightweight UI in `frontend/` lets users submit orders and view them in the browser. Open `frontend/index.html` in a browser while the backend is running.
+
+## Python service
+
+`app.py` provides deposit, withdraw and transfer endpoints with commission tracking. Tests cover this service:
+
+```bash
+pytest
+```

--- a/backend/server.js
+++ b/backend/server.js
@@ -2,23 +2,46 @@ const express = require('express');
 const app = express();
 app.use(express.json());
 
+// simple in-memory data stores
+const markets = ['BTC-USDT', 'ETH-USDT'];
+let orders = [];
+let nextOrderId = 1;
+
 app.get('/', (req, res) => {
   res.send('Crypto Exchange API');
 });
 
-// placeholder route for spot order
-app.post('/spot/order', (req, res) => {
-  res.json({ status: 'spot order endpoint' });
+// return available markets
+app.get('/api/markets', (req, res) => {
+  res.json(markets);
 });
 
-// placeholder route for futures order
-app.post('/futures/order', (req, res) => {
-  res.json({ status: 'futures order endpoint' });
+// place a new order
+app.post('/api/orders', (req, res) => {
+  const { market, side, type, price, amount } = req.body;
+  if (!market || !side || !type || price === undefined || amount === undefined) {
+    return res.status(400).json({ error: 'missing fields' });
+  }
+  if (!markets.includes(market)) {
+    return res.status(400).json({ error: 'unknown market' });
+  }
+  const order = {
+    id: nextOrderId++,
+    market,
+    side,
+    type,
+    price: Number(price),
+    amount: Number(amount),
+    status: 'open',
+    createdAt: new Date().toISOString(),
+  };
+  orders.push(order);
+  res.json(order);
 });
 
-// placeholder route for liquidity provider
-app.post('/liquidity', (req, res) => {
-  res.json({ status: 'liquidity provider endpoint' });
+// list open orders
+app.get('/api/orders/open', (req, res) => {
+  res.json(orders.filter((o) => o.status === 'open'));
 });
 
 const PORT = process.env.PORT || 3000;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,5 +1,53 @@
+const API_BASE = 'http://localhost:3000/api';
+
+function loadMarkets() {
+  fetch(`${API_BASE}/markets`)
+    .then((res) => res.json())
+    .then((markets) => {
+      const select = document.getElementById('market');
+      select.innerHTML = '';
+      markets.forEach((m) => {
+        const opt = document.createElement('option');
+        opt.value = m;
+        opt.textContent = m;
+        select.appendChild(opt);
+      });
+    });
+}
+
+function loadOrders() {
+  fetch(`${API_BASE}/orders/open`)
+    .then((res) => res.json())
+    .then((orders) => {
+      const list = document.getElementById('orders');
+      list.innerHTML = '';
+      orders.forEach((o) => {
+        const li = document.createElement('li');
+        li.textContent = `${o.id} ${o.side} ${o.amount}@${o.price} ${o.market}`;
+        list.appendChild(li);
+      });
+    });
+}
+
+document.getElementById('order-form').addEventListener('submit', (e) => {
+  e.preventDefault();
+  const market = document.getElementById('market').value;
+  const side = document.getElementById('side').value;
+  const price = document.getElementById('price').value;
+  const amount = document.getElementById('amount').value;
+  fetch(`${API_BASE}/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ market, side, type: 'limit', price, amount }),
+  }).then(() => {
+    document.getElementById('price').value = '';
+    document.getElementById('amount').value = '';
+    loadOrders();
+  });
+});
+
 function showPanel(type) {
-  ['spot', 'futures', 'liquidity'].forEach(t => {
+  ['spot', 'futures', 'liquidity'].forEach((t) => {
     const panel = document.getElementById(`${t}-panel`);
     if (t === type) {
       panel.classList.remove('hidden');
@@ -12,3 +60,6 @@ function showPanel(type) {
 document.getElementById('spot-link').addEventListener('click', () => showPanel('spot'));
 document.getElementById('futures-link').addEventListener('click', () => showPanel('futures'));
 document.getElementById('liquidity-link').addEventListener('click', () => showPanel('liquidity'));
+
+loadMarkets();
+loadOrders();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,7 +24,28 @@
       <p>Experience next-gen trading with a sleek and intuitive interface.</p>
     </section>
     <section class="panel-container">
-      <div class="panel" id="spot-panel">Spot trading panel placeholder</div>
+      <div class="panel" id="spot-panel">
+        <form id="order-form">
+          <label>Market
+            <select id="market"></select>
+          </label>
+          <label>Side
+            <select id="side">
+              <option value="buy">Buy</option>
+              <option value="sell">Sell</option>
+            </select>
+          </label>
+          <label>Price
+            <input type="number" id="price" step="0.01" required />
+          </label>
+          <label>Amount
+            <input type="number" id="amount" step="0.0001" required />
+          </label>
+          <button type="submit">Place Order</button>
+        </form>
+        <h3>Open Orders</h3>
+        <ul id="orders"></ul>
+      </div>
       <div class="panel hidden" id="futures-panel">Futures trading panel placeholder</div>
       <div class="panel hidden" id="liquidity-panel">Liquidity provider tools placeholder</div>
     </section>


### PR DESCRIPTION
## Summary
- expand Node backend with simple in-memory markets and order endpoints
- implement basic frontend to place orders and view open orders
- document usage in README and ignore generated files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890ae159b1c832bb261f419bb37053c